### PR TITLE
Update dotgov domain URL

### DIFF
--- a/lib/dotgov_list_fetcher.js
+++ b/lib/dotgov_list_fetcher.js
@@ -9,7 +9,7 @@ class DotgovListFetcher {
   }
 
   perform(callback) {
-    var basePath = 'https://raw.githubusercontent.com/GSA/data/gh-pages/dotgov-domains';
+    var basePath = 'https://raw.githubusercontent.com/GSA/data/master/dotgov-domains';
     var url = `${basePath}/${this.domainsPath}`;
 
     request(url, function(error, response, body) {


### PR DESCRIPTION
I think this repo should probably be deprecated since it's not maintained, but I'll file and merge this for visibility anyway, so that the URL is up to date.